### PR TITLE
Using UIAlertController if min iOS version >= iOS 8 

### DIFF
--- a/ClusterPrePermissions.xcodeproj/project.pbxproj
+++ b/ClusterPrePermissions.xcodeproj/project.pbxproj
@@ -401,7 +401,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ClusterPrePermissions/ClusterPrePermissions-Prefix.pch";
 				INFOPLIST_FILE = "ClusterPrePermissions/ClusterPrePermissions-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getcluster.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = ClusterPrePermissions;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -417,7 +417,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ClusterPrePermissions/ClusterPrePermissions-Prefix.pch";
 				INFOPLIST_FILE = "ClusterPrePermissions/ClusterPrePermissions-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getcluster.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = ClusterPrePermissions;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ClusterPrePermissions.xcodeproj/project.pbxproj
+++ b/ClusterPrePermissions.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		064DCAC11C0323A7002515B1 /* ClusterAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 064DCAC01C0323A7002515B1 /* ClusterAlertView.m */; };
 		65C599CA18F35A4500AE202C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65C599C918F35A4500AE202C /* Foundation.framework */; };
 		65C599CC18F35A4500AE202C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65C599CB18F35A4500AE202C /* CoreGraphics.framework */; };
 		65C599CE18F35A4500AE202C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65C599CD18F35A4500AE202C /* UIKit.framework */; };
@@ -38,6 +39,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		064DCABF1C0323A7002515B1 /* ClusterAlertView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ClusterAlertView.h; path = ClusterPrePermissions/ClusterPrePermissions/ClusterAlertView.h; sourceTree = "<group>"; };
+		064DCAC01C0323A7002515B1 /* ClusterAlertView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ClusterAlertView.m; path = ClusterPrePermissions/ClusterPrePermissions/ClusterAlertView.m; sourceTree = "<group>"; };
 		65C599C618F35A4500AE202C /* ClusterPrePermissions.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ClusterPrePermissions.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		65C599C918F35A4500AE202C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		65C599CB18F35A4500AE202C /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -167,6 +170,8 @@
 			children = (
 				65D1AF1518F4B3BA005ACA29 /* ClusterPrePermissions.h */,
 				65D1AF1618F4B3BA005ACA29 /* ClusterPrePermissions.m */,
+				064DCABF1C0323A7002515B1 /* ClusterAlertView.h */,
+				064DCAC01C0323A7002515B1 /* ClusterAlertView.m */,
 			);
 			name = ClusterPrePermissions;
 			sourceTree = "<group>";
@@ -271,6 +276,7 @@
 			files = (
 				65C599FF18F36ED400AE202C /* PermissionsTestViewController.m in Sources */,
 				65C599D618F35A4500AE202C /* main.m in Sources */,
+				064DCAC11C0323A7002515B1 /* ClusterAlertView.m in Sources */,
 				65D1AF1718F4B3BA005ACA29 /* ClusterPrePermissions.m in Sources */,
 				65C599DA18F35A4500AE202C /* CLAppDelegate.m in Sources */,
 			);
@@ -395,6 +401,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ClusterPrePermissions/ClusterPrePermissions-Prefix.pch";
 				INFOPLIST_FILE = "ClusterPrePermissions/ClusterPrePermissions-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getcluster.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = ClusterPrePermissions;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -410,6 +417,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ClusterPrePermissions/ClusterPrePermissions-Prefix.pch";
 				INFOPLIST_FILE = "ClusterPrePermissions/ClusterPrePermissions-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getcluster.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = ClusterPrePermissions;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ClusterPrePermissions/ClusterPrePermissions/ClusterAlertView.h
+++ b/ClusterPrePermissions/ClusterPrePermissions/ClusterAlertView.h
@@ -1,0 +1,17 @@
+//
+//  ClusterAlertView.h
+//  ClusterPrePermissions
+//
+//  Created by Hossam Ghareeb(hossam.ghareb@gmail.com) on 11/23/15.
+//  Copyright © 2015 Cluster Labs, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef void(^ClusterAlertViewCompletion)(NSInteger selectedOtherButtonIndex);
+
+@interface ClusterAlertView : NSObject
+
+
++(void)showAlertWithTitle:(NSString *)title message:(NSString *)message cancelButtonTitle:(NSString *)cancelTitle otherButtonTitles:(NSArray *)otherButtonTitles completion:(ClusterAlertViewCompletion)completion;
+@end

--- a/ClusterPrePermissions/ClusterPrePermissions/ClusterAlertView.h
+++ b/ClusterPrePermissions/ClusterPrePermissions/ClusterAlertView.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef void(^ClusterAlertViewCompletion)(NSInteger selectedOtherButtonIndex);
+typedef void(^ClusterAlertViewCompletion)(NSInteger selectedButtonIndex);
 
 @interface ClusterAlertView : NSObject
 

--- a/ClusterPrePermissions/ClusterPrePermissions/ClusterAlertView.m
+++ b/ClusterPrePermissions/ClusterPrePermissions/ClusterAlertView.m
@@ -1,0 +1,80 @@
+//
+//  ClusterAlertView.m
+//  ClusterPrePermissions
+//
+//  Created by Hossam Ghareeb on 11/23/15.
+//  Copyright © 2015 Cluster Labs, Inc. All rights reserved.
+//
+
+#import "ClusterAlertView.h"
+
+typedef void (^AlertControllerHandler)(UIAlertAction *action);
+
+@interface ClusterAlertView () <UIAlertViewDelegate>
+
+@property (nonatomic, copy) ClusterAlertViewCompletion completionHandler;
+@end
+@implementation ClusterAlertView
+
+
++(void)showAlertWithTitle:(NSString *)title message:(NSString *)message cancelButtonTitle:(NSString *)cancelTitle otherButtonTitles:(NSArray *)otherButtonTitles completion:(ClusterAlertViewCompletion)completion
+{
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
+    //at least iOS 8 code here
+    
+    __block UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    
+    AlertControllerHandler alertControllerHandler = [^(UIAlertAction *action){
+        if (completion) {
+            completion([alertController.actions indexOfObject:action]);
+        }
+        alertController = nil;
+    } copy];
+    
+    [alertController addAction:[UIAlertAction actionWithTitle:cancelTitle style:UIAlertActionStyleCancel handler:alertControllerHandler]];
+    for (NSString *title in otherButtonTitles) {
+        UIAlertAction *action = [UIAlertAction actionWithTitle:title style:UIAlertActionStyleDefault handler:alertControllerHandler];
+        [alertController addAction:action];
+    }
+    
+    UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+    UIViewController *viewController = keyWindow.rootViewController;
+    while (viewController.presentedViewController) {
+        viewController = viewController.presentedViewController;
+    }
+    
+    [viewController presentViewController:alertController animated:YES completion:nil];
+    
+#endif
+    
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
+    // less than iOS 8 goes here
+    
+    __block ClusterAlertView *clusterAlertView = [[self alloc] init];
+    
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:clusterAlertView cancelButtonTitle:cancelTitle otherButtonTitles: nil];
+    for (NSString *title in otherButtonTitles) {
+        [alertView addButtonWithTitle:title];
+    }
+    
+    clusterAlertView.completionHandler = ^(NSInteger index){
+      
+        if (completion) {
+            completion(index);
+        }
+        clusterAlertView = nil;
+    };
+    
+    [alertView show];
+    
+#endif
+}
+
+-(void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex{
+    
+    if (self.completionHandler) {
+        self.completionHandler(buttonIndex);
+    }
+}
+@end

--- a/ClusterPrePermissions/ClusterPrePermissions/ClusterPrePermissions.m
+++ b/ClusterPrePermissions/ClusterPrePermissions/ClusterPrePermissions.m
@@ -125,6 +125,34 @@ static ClusterPrePermissions *__sharedInstance;
     }
 }
 
++ (ClusterAuthorizationStatus) contactsPermissionAuthorizationStatus
+{
+    ClusterContactsAuthorizationType authType;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0
+    //at least iOS 9 code here
+    CNAuthorizationStatus status = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
+    authType = (ClusterContactsAuthorizationType)status;
+#else
+    //lower than iOS 9 code here
+    ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
+    authType = (ClusterContactsAuthorizationType)status;
+#endif
+    switch (authType) {
+        case ClusterContactsAuthorizationStatusAuthorized:
+            return ClusterAuthorizationStatusAuthorized;
+            
+        case ClusterContactsAuthorizationStatusDenied:
+            return ClusterAuthorizationStatusDenied;
+            
+        case ClusterContactsAuthorizationStatusRestricted:
+            return ClusterAuthorizationStatusRestricted;
+            
+        default:
+            return ClusterAuthorizationStatusUnDetermined;
+    }
+}
+
+
 + (ClusterAuthorizationStatus) eventPermissionAuthorizationStatus:(ClusterEventAuthorizationType)eventType
 {
     EKAuthorizationStatus status = [EKEventStore authorizationStatusForEntityType:

--- a/ClusterPrePermissions/ClusterPrePermissions/ClusterPrePermissions.m
+++ b/ClusterPrePermissions/ClusterPrePermissions/ClusterPrePermissions.m
@@ -43,29 +43,25 @@ typedef NS_ENUM(NSInteger, ClusterTitleType) {
 @import Contacts;
 #endif
 
+#import "ClusterAlertView.h"
+
 NSString *const ClusterPrePermissionsDidAskForPushNotifications = @"ClusterPrePermissionsDidAskForPushNotifications";
 
 @interface ClusterPrePermissions () <UIAlertViewDelegate, CLLocationManagerDelegate>
 
-@property (strong, nonatomic) UIAlertView *preAVPermissionAlertView;
 @property (copy, nonatomic) ClusterPrePermissionCompletionHandler avPermissionCompletionHandler;
 
-@property (strong, nonatomic) UIAlertView *prePhotoPermissionAlertView;
 @property (copy, nonatomic) ClusterPrePermissionCompletionHandler photoPermissionCompletionHandler;
 
-@property (strong, nonatomic) UIAlertView *preContactPermissionAlertView;
 @property (copy, nonatomic) ClusterPrePermissionCompletionHandler contactPermissionCompletionHandler;
 
-@property (strong, nonatomic) UIAlertView *preEventPermissionAlertView;
 @property (copy, nonatomic) ClusterPrePermissionCompletionHandler eventPermissionCompletionHandler;
 
-@property (strong, nonatomic) UIAlertView *preLocationPermissionAlertView;
 @property (copy, nonatomic) ClusterPrePermissionCompletionHandler locationPermissionCompletionHandler;
 @property (strong, nonatomic) CLLocationManager *locationManager;
 
 @property (assign, nonatomic) ClusterLocationAuthorizationType locationAuthorizationType;
 @property (assign, nonatomic) ClusterPushNotificationType requestedPushNotificationTypes;
-@property (strong, nonatomic) UIAlertView *prePushNotificationPermissionAlertView;
 @property (copy, nonatomic) ClusterPrePermissionCompletionHandler pushNotificationPermissionCompletionHandler;
 
 @end
@@ -122,24 +118,6 @@ static ClusterPrePermissions *__sharedInstance;
             return ClusterAuthorizationStatusDenied;
 
         case ALAuthorizationStatusRestricted:
-            return ClusterAuthorizationStatusRestricted;
-
-        default:
-            return ClusterAuthorizationStatusUnDetermined;
-    }
-}
-
-+ (ClusterAuthorizationStatus) contactsPermissionAuthorizationStatus
-{
-    ABAuthorizationStatus status = ABAddressBookGetAuthorizationStatus();
-    switch (status) {
-        case kABAuthorizationStatusAuthorized:
-            return ClusterAuthorizationStatusAuthorized;
-
-        case kABAuthorizationStatusDenied:
-            return ClusterAuthorizationStatusDenied;
-
-        case kABAuthorizationStatusRestricted:
             return ClusterAuthorizationStatusRestricted;
 
         default:
@@ -236,12 +214,18 @@ static ClusterPrePermissions *__sharedInstance;
     if (status == ClusterAuthorizationStatusUnDetermined) {
         self.pushNotificationPermissionCompletionHandler = completionHandler;
         self.requestedPushNotificationTypes = requestedType;
-        self.prePushNotificationPermissionAlertView = [[UIAlertView alloc] initWithTitle:requestTitle
-                                                                                 message:message
-                                                                                delegate:self
-                                                                       cancelButtonTitle:denyButtonTitle
-                                                                       otherButtonTitles:grantButtonTitle, nil];
-        [self.prePushNotificationPermissionAlertView show];
+        
+        [ClusterAlertView showAlertWithTitle:requestTitle message:message cancelButtonTitle:denyButtonTitle otherButtonTitles:@[grantButtonTitle] completion:^(NSInteger selectedButtonIndex) {
+            
+            if (selectedButtonIndex == 0) {
+                // User said NO, that jerk.
+                [self firePushNotificationPermissionCompletionHandler];
+            } else {
+                // User granted access, now try to trigger the real location access
+                [self showActualPushNotificationPermissionAlert];
+            }
+        }];
+        
     } else {
         if (completionHandler) {
             completionHandler((status == ClusterAuthorizationStatusUnDetermined),
@@ -334,13 +318,17 @@ static ClusterPrePermissions *__sharedInstance;
     AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:[self AVEquivalentMediaType:mediaType]];
     if (status == AVAuthorizationStatusNotDetermined) {
         self.avPermissionCompletionHandler = completionHandler;
-        self.preAVPermissionAlertView = [[UIAlertView alloc] initWithTitle:requestTitle
-                                                                   message:message
-                                                                  delegate:self
-                                                         cancelButtonTitle:denyButtonTitle
-                                                         otherButtonTitles:grantButtonTitle, nil];
-        self.preAVPermissionAlertView.tag = mediaType;
-        [self.preAVPermissionAlertView show];
+        [ClusterAlertView showAlertWithTitle:requestTitle message:message cancelButtonTitle:denyButtonTitle otherButtonTitles:@[grantButtonTitle] completion:^(NSInteger selectedButtonIndex) {
+            
+            if (selectedButtonIndex == 0) {
+                // User said NO, jerk.
+                [self fireAVPermissionCompletionHandlerWithType:mediaType];
+            } else {
+                // User granted access, now show the REAL permissions dialog
+                [self showActualAVPermissionAlertWithType:mediaType];
+            }
+            
+        }];
     } else {
         if (completionHandler) {
             completionHandler((status == AVAuthorizationStatusAuthorized),
@@ -446,12 +434,18 @@ static ClusterPrePermissions *__sharedInstance;
     ALAuthorizationStatus status = [ALAssetsLibrary authorizationStatus];
     if (status == ALAuthorizationStatusNotDetermined) {
         self.photoPermissionCompletionHandler = completionHandler;
-        self.prePhotoPermissionAlertView = [[UIAlertView alloc] initWithTitle:requestTitle
-                                                                      message:message
-                                                                     delegate:self
-                                                            cancelButtonTitle:denyButtonTitle
-                                                            otherButtonTitles:grantButtonTitle, nil];
-        [self.prePhotoPermissionAlertView show];
+        
+        [ClusterAlertView showAlertWithTitle:requestTitle message:message cancelButtonTitle:denyButtonTitle otherButtonTitles:@[grantButtonTitle] completion:^(NSInteger selectedButtonIndex) {
+            
+            if (selectedButtonIndex == 0) {
+                // User said NO, jerk.
+                [self firePhotoPermissionCompletionHandler];
+            } else {
+                // User granted access, now show the REAL permissions dialog
+                [self showActualPhotoPermissionAlert];
+            }
+        }];
+
     } else {
         if (completionHandler) {
             completionHandler((status == ALAuthorizationStatusAuthorized),
@@ -538,12 +532,18 @@ static ClusterPrePermissions *__sharedInstance;
     
     if (status == ClusterContactsAuthorizationStatusNotDetermined) {
         self.contactPermissionCompletionHandler = completionHandler;
-        self.preContactPermissionAlertView = [[UIAlertView alloc] initWithTitle:requestTitle
-                                                                        message:message
-                                                                       delegate:self
-                                                              cancelButtonTitle:denyButtonTitle
-                                                              otherButtonTitles:grantButtonTitle, nil];
-        [self.preContactPermissionAlertView show];
+        [ClusterAlertView showAlertWithTitle:requestTitle message:message cancelButtonTitle:denyButtonTitle otherButtonTitles:@[grantButtonTitle] completion:^(NSInteger selectedButtonIndex) {
+
+            if (selectedButtonIndex == 0) {
+                // User said NO, that jerk.
+                [self fireContactPermissionCompletionHandler];
+            } else {
+                // User granted access, now try to trigger the real contacts access
+                [self showActualContactPermissionAlert];
+            }
+            
+        }];
+        
     } else {
         if (completionHandler) {
             completionHandler(status == ClusterContactsAuthorizationStatusAuthorized,
@@ -634,13 +634,17 @@ static ClusterPrePermissions *__sharedInstance;
     EKAuthorizationStatus status = [EKEventStore authorizationStatusForEntityType:[self EKEquivalentEventType:eventType]];
     if (status == EKAuthorizationStatusNotDetermined) {
         self.eventPermissionCompletionHandler = completionHandler;
-        self.preEventPermissionAlertView = [[UIAlertView alloc] initWithTitle:requestTitle
-                                                                      message:message
-                                                                     delegate:self
-                                                            cancelButtonTitle:denyButtonTitle
-                                                            otherButtonTitles:grantButtonTitle, nil];
-        self.preEventPermissionAlertView.tag = eventType;
-        [self.preEventPermissionAlertView show];
+        [ClusterAlertView showAlertWithTitle:requestTitle message:message cancelButtonTitle:denyButtonTitle otherButtonTitles:@[grantButtonTitle] completion:^(NSInteger selectedButtonIndex) {
+            
+            if (selectedButtonIndex == 0) {
+                // User said NO, that jerk.
+                [self fireEventPermissionCompletionHandler:eventType];
+            } else {
+                // User granted access, now try to trigger the real contacts access
+                [self showActualEventPermissionAlert:eventType];
+            }
+            
+        }];
     } else {
         if (completionHandler) {
             completionHandler((status == EKAuthorizationStatusAuthorized),
@@ -732,12 +736,16 @@ static ClusterPrePermissions *__sharedInstance;
     if (status == kCLAuthorizationStatusNotDetermined) {
         self.locationPermissionCompletionHandler = completionHandler;
         self.locationAuthorizationType = authorizationType;
-        self.preLocationPermissionAlertView = [[UIAlertView alloc] initWithTitle:requestTitle
-                                                                         message:message
-                                                                        delegate:self
-                                                               cancelButtonTitle:denyButtonTitle
-                                                               otherButtonTitles:grantButtonTitle, nil];
-        [self.preLocationPermissionAlertView show];
+        [ClusterAlertView showAlertWithTitle:requestTitle message:message cancelButtonTitle:denyButtonTitle otherButtonTitles:@[grantButtonTitle] completion:^(NSInteger selectedButtonIndex) {
+            
+            if (selectedButtonIndex == 0) {
+                // User said NO, that jerk.
+                [self fireLocationPermissionCompletionHandler];
+            } else {
+                // User granted access, now try to trigger the real location access
+                [self showActualLocationPermissionAlert];
+            }
+        }];
     } else {
         if (completionHandler) {
             completionHandler(([self locationAuthorizationStatusPermitsAccess:status]),
@@ -809,67 +817,6 @@ static ClusterPrePermissions *__sharedInstance;
 {
     if (status != kCLAuthorizationStatusNotDetermined) {
         [self fireLocationPermissionCompletionHandler];
-    }
-}
-
-
-#pragma mark - UIAlertViewDelegate
-
-
-- (void) alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
-{
-    if (alertView == self.preAVPermissionAlertView) {
-        if (buttonIndex == alertView.cancelButtonIndex) {
-            // User said NO, jerk.
-            [self fireAVPermissionCompletionHandlerWithType:alertView.tag];
-        } else {
-            // User granted access, now show the REAL permissions dialog
-            [self showActualAVPermissionAlertWithType:alertView.tag];
-        }
-
-        self.preAVPermissionAlertView = nil;
-    } else if (alertView == self.prePhotoPermissionAlertView) {
-        if (buttonIndex == alertView.cancelButtonIndex) {
-            // User said NO, jerk.
-            [self firePhotoPermissionCompletionHandler];
-        } else {
-            // User granted access, now show the REAL permissions dialog
-            [self showActualPhotoPermissionAlert];
-        }
-
-        self.prePhotoPermissionAlertView = nil;
-    } else if (alertView == self.preContactPermissionAlertView) {
-        if (buttonIndex == alertView.cancelButtonIndex) {
-            // User said NO, that jerk.
-            [self fireContactPermissionCompletionHandler];
-        } else {
-            // User granted access, now try to trigger the real contacts access
-            [self showActualContactPermissionAlert];
-        }
-    } else if (alertView == self.preEventPermissionAlertView) {
-        if (buttonIndex == alertView.cancelButtonIndex) {
-            // User said NO, that jerk.
-            [self fireEventPermissionCompletionHandler:alertView.tag];
-        } else {
-            // User granted access, now try to trigger the real contacts access
-            [self showActualEventPermissionAlert:alertView.tag];
-        }
-    } else if (alertView == self.preLocationPermissionAlertView) {
-        if (buttonIndex == alertView.cancelButtonIndex) {
-            // User said NO, that jerk.
-            [self fireLocationPermissionCompletionHandler];
-        } else {
-            // User granted access, now try to trigger the real location access
-            [self showActualLocationPermissionAlert];
-        }
-    } else if (alertView == self.prePushNotificationPermissionAlertView) {
-        if (buttonIndex == alertView.cancelButtonIndex) {
-            // User said NO, that jerk.
-            [self firePushNotificationPermissionCompletionHandler];
-        } else {
-            // User granted access, now try to trigger the real location access
-            [self showActualPushNotificationPermissionAlert];
-        }
     }
 }
 


### PR DESCRIPTION
Now all warnings of using UIAlertView have gone.
Added ClusterAlertView that handles using UIAlertView or UIAlertController based on minimum iOS supported.
